### PR TITLE
Ensure constant beam count for ROS2 SLAM Toolkit and Nav2 to work

### DIFF
--- a/ldlidar_driver/src/log_module.cpp
+++ b/ldlidar_driver/src/log_module.cpp
@@ -27,6 +27,9 @@
 #include <stdlib.h>
 #endif
 
+// Ubuntu 24.04 won't compile without this include:
+#include <pthread.h>
+
 //使用vswprintf会出现奔溃的情况如果，传入数据大于 VA_PARAMETER_MAX 就会出现崩溃
 #define  VA_PARAMETER_MAX  (1024 * 2)
 

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -48,6 +48,10 @@ int main(int argc, char **argv) {
   int serial_baudrate = 0;
   ldlidar::LDType lidartypename = ldlidar::LDType::NO_VER;
 
+  // Added to measure average beam count (points per revolution) at start:
+  int beam_count = 0;
+  int beam_count_i = 0;
+
   // declare ros2 param
   node->declare_parameter<std::string>("product_name", product_name);
   node->declare_parameter<std::string>("laser_scan_topic_name", laser_scan_topic_name);
@@ -137,8 +141,25 @@ int main(int argc, char **argv) {
       case ldlidar::LidarStatus::NORMAL: {
         double lidar_scan_freq = 0;
         lidar_drv->GetLidarScanFreq(lidar_scan_freq);
-        ToLaserscanMessagePublish(laser_scan_points, lidar_scan_freq, setting, node, lidar_pub_laserscan);
-        ToSensorPointCloudMessagePublish(laser_scan_points, setting, node, lidar_pub_pointcloud);
+        int n_points = static_cast<int>(laser_scan_points.size());
+        int n_samples = 20;
+        if(beam_count_i++ < n_samples) {
+          // Measure average beam count (points per revolution) at start:
+          if(beam_count_i > 1) {
+            // skip the first sample, it is messed up
+            beam_count += n_points;
+          }
+          //RCLCPP_INFO(node->get_logger(), "beam count: %d", n_points);
+          if(beam_count_i == n_samples) {
+            beam_count = beam_count / (n_samples - 1);
+            RCLCPP_INFO(node->get_logger(), "Average beam count: %d", beam_count);
+          }
+        } else if(n_points > beam_count - 5) {
+          // ensure the size of points vector is constant between LIDAR head revolutions:
+          laser_scan_points.resize(beam_count, laser_scan_points.back());
+          ToLaserscanMessagePublish(laser_scan_points, lidar_scan_freq, setting, node, lidar_pub_laserscan);
+          ToSensorPointCloudMessagePublish(laser_scan_points, setting, node, lidar_pub_pointcloud);
+        }
         break;
       }
       case ldlidar::LidarStatus::DATA_TIME_OUT: {


### PR DESCRIPTION
I am using LD14 device with the following launch description:
```
    ldlidar_node = Node(
        package='ldlidar_sl_ros2',
        executable='ldlidar_sl_ros2_node',
        name='ldlidar_publisher_ld14',
        output='screen',
        respawn=True,
        respawn_delay=10,
        parameters=[
          {'product_name': 'LDLiDAR_LD14'},
          {'laser_scan_topic_name': 'scan'},
          {'point_cloud_2d_topic_name': 'pointcloud2d'},
          {'frame_id': 'laser_frame'},
          {'port_name': '/dev/ttyUSBLDR'},
          {'serial_baudrate' : 115200},
          {'laser_scan_dir': True},
          {'enable_angle_crop_func': False},
          {'angle_crop_min': 135.0},
          {'angle_crop_max': 225.0}
        ]
    )
```
The "_demo.cpp_" code passes each LIDAR head rotation "_beams vector_" as it comes from the driver, with the beam count dependent on the head rotation speed. In my case, the beam count varies in the range 388...393, so that the "/scan" topic is also containing variable point count. ROS2 Jazzy SLAM Toolbox treats this as error - it expects all incoming messages to contain the same amount of points.

To fix that, I added code to measure an average of 20 first valid scans (first scan is skipped as it always comes truncated), and to resize the resulting "_scan vector_" to that average size (if it needs expanding in the process, the last element is used to fill the void). So, all messages come to ROS2 with the same point count.

The modification is tested on Raspberry Pi 5 under Ubuntu 24.04 and ROS2 Jazzy. SLAM Toolbox and Nav2 works fine now.

More detail about that robot is here: https://github.com/slgrobotics/robots_bringup/blob/main/Docs/Dragger/README.md
