### PR TITLE
Fix missing #include <pthread>

### DIFF
--- a/ldlidar_driver/include/log_module.h
+++ b/ldlidar_driver/include/log_module.h
@@ -37,7 +37,7 @@
 #ifndef LINUX
 #include <windows.h>
 #else
-//#include <pthread.h>
+#include <pthread.h>
 #include <stdarg.h>
 #define printf_s(fileptr,str)  (fprintf(fileptr,"%s",str))
 #define __in


### PR DESCRIPTION
The #include <pthread> header was missing, which caused compilation errors when using threading functions. This PR adds the necessary include statement.