### PR TITLE
Add angle offset parameter to resolve measurement angle and actual direction misalignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Parameter Description:
       {'angle_crop_min': 135.0}
       {'angle_crop_max': 225.0}
       which is [135.0, 225.0], angle unit is degress.
+- Angle offset setting, Apply a fixed clockwise offset to all angles:
+  - The angle offset is applied in clockwise direction, unit is degrees.
+    example:
+      {'angle_offset': 180.0}
 '''
 
 def generate_launch_description():
@@ -69,7 +73,8 @@ def generate_launch_description():
         {'laser_scan_dir': True},
         {'enable_angle_crop_func': False},
         {'angle_crop_min': 135.0},
-        {'angle_crop_max': 225.0}
+        {'angle_crop_max': 225.0},
+        {'angle_offset': 0.0}
       ]
   )
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -48,6 +48,10 @@ Parameter Description:
       {'angle_crop_min': 135.0}
       {'angle_crop_max': 225.0}
       which is [135.0, 225.0], angle unit is degress.
+- Angle offset setting, Apply a fixed clockwise offset to all angles:
+  - The angle offset is applied in clockwise direction, unit is degrees.
+    example:
+      {'angle_offset': 180.0}
 '''
 
 def generate_launch_description():
@@ -67,7 +71,8 @@ def generate_launch_description():
         {'laser_scan_dir': True},
         {'enable_angle_crop_func': False},
         {'angle_crop_min': 135.0},
-        {'angle_crop_max': 225.0}
+        {'angle_crop_max': 225.0},
+        {'angle_offset': 0.0}
       ]
   )
 

--- a/include/ros2_api.h
+++ b/include/ros2_api.h
@@ -35,6 +35,7 @@ struct LaserScanSetting
   bool enable_angle_crop_func;
   double angle_crop_min;
   double angle_crop_max;
+  double angle_offset;
 };
 
 #endif //__ROS_API_H__

--- a/launch/ld14.launch.py
+++ b/launch/ld14.launch.py
@@ -19,6 +19,10 @@ Parameter Description:
       {'angle_crop_min': 135.0}
       {'angle_crop_max': 225.0}
       which is [135.0, 225.0], angle unit is degress.
+- Angle offset setting, Apply a fixed clockwise offset to all angles:
+  - The angle offset is applied in clockwise direction, unit is degrees.
+    example:
+      {'angle_offset': 180.0}
 '''
 
 def generate_launch_description():
@@ -38,7 +42,8 @@ def generate_launch_description():
         {'laser_scan_dir': True},
         {'enable_angle_crop_func': False},
         {'angle_crop_min': 135.0},
-        {'angle_crop_max': 225.0}
+        {'angle_crop_max': 225.0},
+        {'angle_offset': 0.0}
       ]
   )
 

--- a/launch/ld14p.launch.py
+++ b/launch/ld14p.launch.py
@@ -38,7 +38,8 @@ def generate_launch_description():
         {'laser_scan_dir': True},
         {'enable_angle_crop_func': False},
         {'angle_crop_min': 135.0},
-        {'angle_crop_max': 225.0}
+        {'angle_crop_max': 225.0},
+        {'angle_offset': 0.0}
       ]
   )
 

--- a/ldlidar_driver/src/log_module.cpp
+++ b/ldlidar_driver/src/log_module.cpp
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 #endif
 
+#include <pthread.h>
+
 //使用vswprintf会出现奔溃的情况如果，传入数据大于 VA_PARAMETER_MAX 就会出现崩溃
 #define  VA_PARAMETER_MAX  (1024 * 2)
 


### PR DESCRIPTION
When using the LD14 LiDAR, I found that while the `laser_scan_dir` parameter can adjust the scanning direction of the LiDAR, I subsequently discovered that although the scanning direction can be adjusted, it cannot align with my LiDAR coordinate system. In my case, while the LiDAR's scanning direction was correct, there was a consistent 180-degree deviation between the data displayed in RViz2 and the actual environment.

To make my robot function properly, I needed to apply a 180-degree clockwise offset to the measured angles while setting the LiDAR to counterclockwise scanning. However, the launch file only provided the option to set the LiDAR's scanning direction (laser_scan_dir), but lacked the ability to apply an angular offset to the measurement data.

Therefore, I have added an `angle_offset` parameter to apply a clockwise offset to the measured angles, with the unit in degrees.

我使用LD14时发现使用 laser_scan_dir 参数确实能调整雷达的扫描方向，但是紧接着我就发现扫描方向虽然可以调整，但是不能和我的雷达坐标系对齐(在我这雷达的扫描方向对了，但是在rviz2中发现和实际固定偏差了180度)。

我需要将测量数据的角度顺时针偏置180度然后设置雷达逆时针扫描，我的机器人才能正常工作，但是launch文件中只提供了设置激光雷达扫描方向（laser_scan_dir）的选项，没有提供对测量数据的角度进行偏置的功能。

所以我添加了一个 angle_offset 参数用于顺时针偏置测量的角度，单位为度